### PR TITLE
Remove count from disk attachment

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -261,7 +261,7 @@ resource "azurerm_managed_disk" "this" {
 
 # Attach shared data disk to DSVM
 resource "azurerm_virtual_machine_data_disk_attachment" "this" {
-  managed_disk_id    = azurerm_managed_disk.this[count.index].id
+  managed_disk_id    = azurerm_managed_disk.this.id
   virtual_machine_id = azurerm_linux_virtual_machine.dsvm.id
   lun                = "0"
   caching            = "ReadWrite"


### PR DESCRIPTION
<!--
Thank you for contributing!

Please complete the following sections to the best of your ability when you submit your Pull Request.
You are encouraged to keep this top level comment box updated as you develop and respond to reviews.

Note that text within html comment tags will not be rendered.
-->

### Summary
<!--
Describe the problem to be fixed or feature to be implemented in this Pull Request.
Please reference any related issue(s) and use fixes/closes keywords to automatically close them, if pertinent.
For example: "fixes #58", or "related to #238"
-->

A `count` index remained in the shared data disk attachment block which caused an error when running Terraform. This was left over from when that disk was optional.
