### PR TITLE
Change default sizes to those with temp disk

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -18,8 +18,8 @@ variable "domain" {
 variable "vm_size" {
   type = map(string)
   default = {
-    guacamole = "Standard_D4s_v4"
-    dsvm      = "Standard_D32s_v4"
+    guacamole = "Standard_D4s_v3"
+    dsvm      = "Standard_D32s_v3"
   }
 }
 


### PR DESCRIPTION
This should help improve changing VM size as sizes with temporary disks
are more common (and include GPU sizes).

<!--
Thank you for contributing!

Please complete the following sections to the best of your ability when you submit your Pull Request.
You are encouraged to keep this top level comment box updated as you develop and respond to reviews.

Note that text within html comment tags will not be rendered.
-->

### Summary
<!--
Describe the problem to be fixed or feature to be implemented in this Pull Request.
Please reference any related issue(s) and use fixes/closes keywords to automatically close them, if pertinent.
For example: "fixes #58", or "related to #238"
-->


### List of changes proposed in this Pull Request
<!-- We suggest using bullets (indicated by - or *) and/or checkboxes (- [ ] unfilled, - [x] or filled). -->

- Change default sizes to `Standard_D32s_v3` and `Standard_D4s_v3`

### What should a reviewer concentrate their feedback on?
<!--
This section is particularly useful if you have a Pull Request that is still in development.
You can guide the reviews to focus on the parts that are ready for their comments.
We suggest using bullets (indicated by - or *) and/or checkboxes (- [ ] unfilled, - [x] filled).
-->
- [ ] Everything looks ok?

### Updates
<!-- As the Pull Request progresses, we encourage you to update this section with major or important developments. -->
